### PR TITLE
Capitalised page titles

### DIFF
--- a/blog.html
+++ b/blog.html
@@ -9,7 +9,7 @@ permalink: /blog/
     <div class="row">
       <div class="col-md-12">
         <div class="block">
-          <h1>Coding Club updates and tutorials</h1>
+          <h1>CODING CLUB UPDATES</h1>
           <b><p><big>Read about our experience with Coding Club and check out our tutorials. Each tutorial post includes instructions and a link to the Github repository from where you can download all files necessary to participate in our workshops remotely.</big></p></b>
         </div>
       </div>

--- a/contact.html
+++ b/contact.html
@@ -10,7 +10,7 @@ permalink: /contact/
     <div class="row">
       <div class="col-md-12">
         <div class="block">
-          <h1>Get in touch</h1>
+          <h1>GET IN TOUCH</h1>
           <b><p><big>We are very keen to discuss ways to innovate teaching in quantitative analysis, and are also happy to share our experience in creating and leading Coding Club. Feel free to contact us with any questions or feedback - we would really appreciate your input!</big></p></b>
         </div>
       </div>

--- a/links.html
+++ b/links.html
@@ -10,7 +10,7 @@ permalink: /links/
         <div class="row">
             <div class="col-md-12">
                 <div class="block">
-                    <h1>Useful Links</h1>
+                    <h1>USEFUL LINKS</h1>
                     <b><p><big>A hand-picked list of resources that we used when learning to code and still refer back to frequently.</big></p></b>
                 </div>
             </div>

--- a/team.html
+++ b/team.html
@@ -10,7 +10,7 @@ permalink: /team/
         <div class="row">
             <div class="col-md-12">
                 <div class="block">
-                    <h1>Our team</h1>
+                    <h1>OUR TEAM</h1>
                     <b><p><big>We are working with great people with a strong motivation to teach and learn - here you can read more about the Coding Club team and our collaborators.</big></p></b>
                 </div>
             </div>


### PR DESCRIPTION
I thought it looked smarter if all the page titles were either capitalised or not, in `master`, the homepage and tutorials pages are capitalised but no others