### PR TITLE
read_csv vs read.csv

### DIFF
--- a/_posts/2017-03-21-data-clustering.md
+++ b/_posts/2017-03-21-data-clustering.md
@@ -85,7 +85,7 @@ Each species has a `SppID` number and a code, which is in the `Species.code` col
 
 ```r
 # Load the dataframe containing all sites NeoTropTree has in Bolivia.
-sites <- read.csv("sites_bolivia.csv", sep=",", head=TRUE)
+sites <- read_csv("sites_bolivia.csv", sep=",", head=TRUE)
 head(sites)
 dim(sites)
 ```


### PR DESCRIPTION
John found that read.csv doesn't work when reading object `sites`. read_csv does however. It might be worth changing all read.csv to read_csv to avoid confusion as long as this doesn't break the analysis