### PR TITLE
Update 2017-03-20-seecc.md

### DIFF
--- a/_posts/2017-03-20-seecc.md
+++ b/_posts/2017-03-20-seecc.md
@@ -518,7 +518,9 @@ We will go through different steps to download, clean and visualise this type of
 First install and load all the package needed.
 
 ```r
-library(rgbif)
+install.packages("devtools")
+library("devtools")
+install_version("rgbif", version = "0.9.9", repos = "http://cran.us.r-project.org")
 ```
 
 __The package `rgbif` offers an interface to the Web Service methods provided by GBIF. It includes functions for searching for taxonomic names, retrieving information on data providers, getting species occurrence records and getting counts of occurrence records.__


### PR DESCRIPTION
issue with the gbifmap function- it just doesn't seem to be supported anymore if you install the current package (1.1.0)? It still seems to exist in version 0.9.9 so I included a couple of lines to make sure people download the right package version..