### PR TITLE
Beverly added sep = tab for Flickr part of tutorial

### DIFF
--- a/_posts/2017-03-20-seecc.md
+++ b/_posts/2017-03-20-seecc.md
@@ -561,7 +561,7 @@ We will now use the dataset flickr_puffins.txt. This dataset has been collected 
 First, load the dataset and have a look at it.
 
 ```r
-flickr <- read.table("./flickr_puffins.txt", header = T)
+flickr <- read.table("./flickr_puffins.txt", header = T, sep = "\t")
 str(flickr)
 ```
 


### PR DESCRIPTION
I think the tutorial is missing sep = tab which causes the text file to be read wrongly and separating the date and time variables into separate columns, while it should be under the same column of "date taken". 