### PR TITLE
Added read-time partial for blog using standard words per min

### DIFF
--- a/_includes/read-time.html
+++ b/_includes/read-time.html
@@ -1,0 +1,18 @@
+<span class="read-time">
+  {{ include.bracket_start }}
+
+  {% if include.approx == 'true' %}
+  ~
+  {% endif %}
+
+  {% assign words = include.content | number_of_words %}
+
+  {% if words < 360 %}
+    1 {{ include.unit }}
+  {% else %}
+    {{ words | divided_by:180 }} {{ include.unit }}s
+  {% endif %}
+
+  {{ include.caption }}
+  {{ include.bracket_end }}
+</span>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,18 @@ layout: page
           <div class="block">
             <h1>{{ page.title }}</h1>
             <div class="post-info-wrapper">
-              <p class="italic">By <span class="bold">{{ page.author }}</span> on <span class="bold">{{ page.date | date: "%B %-d, %Y" }}</span></p>
+              <p class="italic">By 
+                <span class="bold">{{ page.author }}</span> on 
+                <span class="bold">{{ page.date | date: "%B %-d, %Y" }}</span>
+                {% include read-time.html
+                           content=content
+                           bracket_start='('
+                           bracket_end=')'
+                           unit='min'
+                           approx='true'
+                           caption='read'
+                %}
+              </p>
             </div>
             <hr />
             <p>{{ content }}</p>

--- a/blog.html
+++ b/blog.html
@@ -19,7 +19,16 @@ permalink: /blog/
 {% for post in site.posts %}
 <div class="post-area">
   <a href="{{ post.url | prepend: site.baseurl }}" class="bold">{{ post.title }}</a>
-  <p class="post-date">{{ post.date | date_to_long_string }}</p>
+  <p class="post-date">{{ post.date | date_to_long_string }}
+  {% include read-time.html
+             content=post.content
+             bracket_start='('
+             bracket_end=')'
+             unit='min'
+             approx='true'
+            caption='read'
+  %}
+  </p>
   <p>
     {{ post.content | strip_html | truncatewords: 50 }}
   </p>


### PR DESCRIPTION
Added read time to blog landing page and individual blog.
Used standards `180 words`/`min`.

## Blogs
<img width="1439" alt="screenshot 2019-03-02 at 4 59 22 pm" src="https://user-images.githubusercontent.com/1132451/53681275-2835e280-3d0d-11e9-8dbf-7f657c9f94ab.png">

## Blog Post
<img width="1439" alt="screenshot 2019-03-02 at 4 59 31 pm" src="https://user-images.githubusercontent.com/1132451/53681276-2835e280-3d0d-11e9-9481-7cf816081cbc.png">
